### PR TITLE
useCapture required for Firefox < 6

### DIFF
--- a/hide-address-bar.js
+++ b/hide-address-bar.js
@@ -29,6 +29,6 @@
 					win.scrollTo( 0, scrollTop === 1 ? 0 : 1 );
 				}
 			}, 0);
-		} );
+		}, false );
 	}
 })( this );


### PR DESCRIPTION
`useCapture` parameter is required in versions of Firefox below v6. This was causing fatal errors and blocking the rest of the JavaScripts on the page.
